### PR TITLE
fix(BIO-582): warning str

### DIFF
--- a/src/pysynthbio/key_handlers.py
+++ b/src/pysynthbio/key_handlers.py
@@ -67,8 +67,7 @@ def set_synthesize_token(use_keyring=False, token=None):
                 )
         else:
             warnings.warn(
-                "Package 'keyring' is not installed.",
-                "Token not stored in keyring.",
+                "Package 'keyring' is not installed. Token not stored in keyring.",
                 stacklevel=2,
             )
             print("To store token in keyring, install with: pip install keyring")


### PR DESCRIPTION
# Summary

Addresses bug in warning string 

# Request for Reviewers

Test that warnings work if you try to save in keyring when keyring package is not installed

# How Has This Been Tested?

Tested in fresh env

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
