### PR TITLE
fix(sec-388): audit and pin github workflow actions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup UV and Python
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           python-version: "3.12"
 

--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0 # Full history for proper versioning
 
       - name: Set up Python
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           python-version: "3.12" # Use the latest stable Python for building
 
@@ -48,7 +48,7 @@ jobs:
           pytest
 
       - name: Build package
-        run: python -m build
+        run: python -m build --no-isolation
 
       - name: Verify package
         run: |
@@ -76,10 +76,9 @@ jobs:
           path: dist/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: dist/*
-          generate_release_notes: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "${GITHUB_REF_NAME}" dist/* --generate-notes
 
   publish-to-testpypi:
     name: Publish to TestPyPI
@@ -99,7 +98,7 @@ jobs:
           path: dist/
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
@@ -122,4 +121,4 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1

--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          uv pip install build twine
+          uv pip install build twine setuptools
           uv sync --all-extras --dev
 
       - name: Verify version matches tag

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Build package
         run: |
-          uv pip install build
+          uv pip install build setuptools
           python -m build --no-isolation
 
       - name: Store built package

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup UV and Python
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           python-version: "3.12"
 
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup UV and Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -73,14 +73,14 @@ jobs:
           fetch-depth: 0
 
       - name: Setup UV and Python
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           python-version: "3.12"
 
       - name: Build package
         run: |
           uv pip install build
-          python -m build
+          python -m build --no-isolation
 
       - name: Store built package
         uses: actions/upload-artifact@v4
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup UV and Python
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
<!-- From https://axolo.co/blog/p/part-3-github-pull-request-template--> 

# Summary

Pins third party github workflow actions to commit SHAs and not mutable version tags.
Removes softprops/action-gh-release github action.


# Request for Reviewers

<!-- What areas should reviewers pay special attention to? Is there any additional information they need to know to review this appropriately?  --> 

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration --> 


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
