### PR TITLE
docs(APP-2289): fix api-keys link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ If you'd prefer 1-click dataset generation and analysis, try our [web platform](
 
 ## Prerequisites
 
-Create a [Synthesize Bio](https://app.synthesize.bio/) account and generate an [API Key](https://app.synthesize.bio/account/api-key).
+Create a [Synthesize Bio](https://app.synthesize.bio/) account and generate an [API Key](https://app.synthesize.bio/account/api-keys).
 
 ## Installation
 

--- a/index.rst
+++ b/index.rst
@@ -19,6 +19,7 @@ pysynthbio documentation
    usage/baseline
    usage/reference-conditioning
    usage/metadata-prediction
+   usage/available-metadata
 
 .. toctree::
    :maxdepth: 1

--- a/usage/available-metadata.rst
+++ b/usage/available-metadata.rst
@@ -1,0 +1,10 @@
+Available Metadata
+==================
+
+Every model on Synthesize Bio accepts specific metadata fields as inputs—things like cell type, tissue, disease state, and perturbation details. The valid values for each field (e.g. ontology IDs, cell line names) are defined by the model's vocabulary.
+
+You can browse and download the vocabulary for any model you have access to at:
+
+`app.synthesize.bio/docs/vocab <https://app.synthesize.bio/docs/vocab>`_
+
+Select a model from the dropdown to see all available fields, and use the download links to get the full list of valid values for each field as JSON.

--- a/usage/getting-started.rst
+++ b/usage/getting-started.rst
@@ -102,6 +102,13 @@ See :doc:`metadata-prediction` for detailed usage.
 
 Only baseline models are available to all users. You can check which models are available programmatically, see ``list_models()``. Contact us at support@synthesize.bio if you have any questions.
 
+Exploring Available Metadata
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Each model accepts a specific set of metadata fields with defined vocabularies (valid ontology IDs, cell lines, tissues, etc.). You can browse and download these vocabularies at `app.synthesize.bio/docs/vocab <https://app.synthesize.bio/docs/vocab>`_.
+
+See :doc:`available-metadata` for more details.
+
 Listing Available Models
 ^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Summary

- Adds a new `usage/available-metadata.rst` page pointing users to [app.synthesize.bio/docs/vocab](https://app.synthesize.bio/docs/vocab) to browse and download available metadata vocabularies by model
- Links to the new page from the Getting Started guide
- Fixes a broken link in `README.md`: `/account/api-key` → `/account/api-keys`

## Test plan

- [ ] Verify the new docs page renders correctly in Sphinx
- [ ] Confirm the link to app.synthesize.bio/docs/vocab is correct once APP-2289 is deployed

Made with [Cursor](https://cursor.com)