### PR TITLE
feat(APP-2292): Enable immutable releases for pysynthbio

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup UV and Python
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
@@ -41,13 +41,13 @@ jobs:
           sphinx-build -b html . _build/html
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: "_build/html"
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -3,39 +3,36 @@ name: Release to PyPI
 on:
   push:
     tags:
-      - "v*" # Trigger on version tags (v1.0.0, v0.2.3, etc.)
+      - "v*"
+
+permissions: {}
 
 jobs:
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0 # Full history for proper versioning
+          fetch-depth: 0
 
       - name: Set up Python
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
-          python-version: "3.12" # Use the latest stable Python for building
+          python-version: "3.12"
 
       - name: Install build dependencies
         run: |
-          uv pip install build twine setuptools
+          uv pip install build twine setuptools toml
           uv sync --all-extras --dev
 
       - name: Verify version matches tag
         run: |
-          # Extract tag version (remove the 'v' prefix)
           TAG_VERSION=${GITHUB_REF#refs/tags/v}
-
-          uv pip install toml 
-
-          # Extract version from your package
           PACKAGE_VERSION=$(python -c "import toml; print(toml.load('pyproject.toml')['project']['version'])")
-
-          # Verify they match
           if [ "$TAG_VERSION" != "$PACKAGE_VERSION" ]; then
             echo "Version mismatch: Tag version ($TAG_VERSION) doesn't match package version ($PACKAGE_VERSION)"
             exit 1
@@ -51,12 +48,10 @@ jobs:
         run: python -m build --no-isolation
 
       - name: Verify package
-        run: |
-          uv pip install twine
-          twine check dist/*
+        run: twine check dist/*
 
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: python-package-distributions
           path: dist/
@@ -66,14 +61,21 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     permissions:
-      contents: write # Required for creating GitHub releases
+      contents: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           name: python-package-distributions
           path: dist/
+
+      - name: Generate build provenance attestations
+        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
+        with:
+          subject-path: dist/*
 
       - name: Create GitHub Release
         env:
@@ -92,7 +94,7 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           name: python-package-distributions
           path: dist/
@@ -115,7 +117,7 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -18,7 +18,7 @@ jobs:
     name: Code Quality
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup UV and Python
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
@@ -49,7 +49,7 @@ jobs:
       SYNTHESIZE_API_KEY: ${{ secrets.SYNTHESIZE_API_KEY }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup UV and Python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -83,7 +83,7 @@ jobs:
           python -m build --no-isolation
 
       - name: Store built package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist
           path: dist/
@@ -93,7 +93,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup UV and Python
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5


### PR DESCRIPTION
## Summary

- Add SLSA build provenance attestations to the release workflow via `actions/attest-build-provenance`, generating cryptographically verifiable provenance for all distribution files
- Pin all remaining `actions/*` references (`checkout`, `upload-artifact`, `download-artifact`, `configure-pages`, `upload-pages-artifact`, `deploy-pages`) to immutable commit SHAs
- Drop default workflow permissions with `permissions: {}` on the release workflow and add `attestations: write` + `id-token: write` to the release job

These changes complement the repository-level release immutability setting (already enabled) so that the next release produces both GitHub release attestations and SLSA build provenance attestations.

## Test plan

- [ ] Verify CI passes on this PR (test-package workflow)
- [ ] Confirm next tag push produces attestations and an immutable GitHub release
- [ ] Verify PyPI publish still works with trusted publishing


Made with [Cursor](https://cursor.com)