### PR TITLE
Fix release workflow version check; bump to 4.2.1

### DIFF
--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -26,13 +26,17 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          uv pip install build twine setuptools toml
+          uv pip install build twine setuptools
           uv sync --all-extras --dev
 
       - name: Verify version matches tag
         run: |
           TAG_VERSION=${GITHUB_REF#refs/tags/v}
-          PACKAGE_VERSION=$(python -c "import toml; print(toml.load('pyproject.toml')['project']['version'])")
+          # Read [project].version without a non-stdlib module or a specific
+          # interpreter on PATH. The previous `python -c "import toml"` failed
+          # with ModuleNotFoundError because toml was only installed in the uv
+          # venv, not the python resolved here.
+          PACKAGE_VERSION=$(grep -m1 -E '^version *= *"' pyproject.toml | sed -E 's/^version *= *"([^"]+)".*/\1/')
           if [ "$TAG_VERSION" != "$PACKAGE_VERSION" ]; then
             echo "Version mismatch: Tag version ($TAG_VERSION) doesn't match package version ($PACKAGE_VERSION)"
             exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pysynthbio"
-version = "4.2.0"
+version = "4.2.1"
 requires-python = ">=3.10"
 description = "A package to retrieve data and models from Synthesize Bio's API"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -891,7 +891,7 @@ wheels = [
 
 [[package]]
 name = "pysynthbio"
-version = "4.2.0"
+version = "4.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
## Why

The `v4.2.0` release run failed at the **Verify version matches tag** step:

```
ModuleNotFoundError: No module named 'toml'
```

This was a workflow bug, not a version mismatch: `toml` was `uv pip install`ed into the uv venv, but the bare `python` resolved in that step couldn't import it. Bumping the version alone (e.g. retrying 4.2.0) would hit the same failure.

`4.2.0` was never published — the run failed before the build/publish/release jobs — so PyPI `4.2.0` is still free, but a clean `4.2.1` tag avoids re-using a burned tag.

## Changes

- **`new-release.yml`**: replace `python -c "import toml; ..."` with a stdlib `grep`/`sed` read of `[project].version` (no extra dependency, no interpreter ambiguity). Drop the now-unneeded `toml` from build deps.
- **Version**: `4.2.0` → `4.2.1` (+ `uv.lock`). Code is otherwise identical to the smoke-tested `4.2.0`.

## Test plan

- [x] `grep -m1 -E '^version *= *"' pyproject.toml | sed -E 's/.../\1/'` prints exactly `4.2.1` (single match; `target-version` lines don't match)
- [x] `uv run pytest` — 49 passed
- [x] `uv run ruff check .` / `uv run black --check .` — clean
- [ ] After merge: `git tag v4.2.1 && git push origin v4.2.1` → release workflow goes green and publishes to PyPI

Made with [Cursor](https://cursor.com)