### PR TITLE
Fix release build step (uv build); bump to 4.2.2

### DIFF
--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -24,10 +24,8 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install build dependencies
-        run: |
-          uv pip install build twine setuptools
-          uv sync --all-extras --dev
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
 
       - name: Verify version matches tag
         run: |
@@ -44,15 +42,16 @@ jobs:
           echo "Version verification passed: $PACKAGE_VERSION"
 
       - name: Run tests
-        run: |
-          uv pip install pytest
-          pytest
+        run: uv run pytest
 
       - name: Build package
-        run: python -m build --no-isolation
+        # uv build resolves the PEP 517 backend (setuptools) in an isolated
+        # env, so it does not depend on setuptools being present in the synced
+        # venv (uv sync prunes anything not in the lockfile).
+        run: uv build
 
       - name: Verify package
-        run: twine check dist/*
+        run: uvx twine check dist/*
 
       - name: Store the distribution packages
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pysynthbio"
-version = "4.2.1"
+version = "4.2.2"
 requires-python = ">=3.10"
 description = "A package to retrieve data and models from Synthesize Bio's API"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -891,7 +891,7 @@ wheels = [
 
 [[package]]
 name = "pysynthbio"
-version = "4.2.1"
+version = "4.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },


### PR DESCRIPTION
## Why

After #60 fixed the version-check step, the `v4.2.1` release run failed at the next step:

```
python -m build --no-isolation
ERROR Backend 'setuptools.build_meta' is not available.
```

Root cause: build deps were installed via `uv pip install build twine setuptools`, then the subsequent `uv sync --all-extras --dev` **pruned** them (sync removes anything not in the lockfile), so the setuptools backend was gone by build time.

Neither `4.2.0` nor `4.2.1` ever published to PyPI (both runs died before the publish job; PyPI latest is still `4.1.0`). Bumping to `4.2.2` and tagging fresh avoids mutating the already-pushed `v4.2.1` tag.

## Changes

- **`new-release.yml`** (commit from the prior branch): switch to uv-native steps — `uv sync`, `uv run pytest`, `uv build` (resolves the PEP 517 setuptools backend in isolation, independent of the synced venv), `uvx twine check`.
- **Version**: `4.2.1` → `4.2.2` (+ `uv.lock`). Code is otherwise identical to the smoke-tested `4.2.0`/`4.2.1`.

## Test plan (reproduced locally, exactly as CI runs)

- [x] version grep prints `4.2.2`
- [x] `uv sync --all-extras --dev`
- [x] `uv run pytest` — 49 passed, 2 skipped
- [x] `uv build` — sdist + wheel produced
- [x] `uvx twine check dist/*` — both PASSED
- [ ] After merge: `git tag v4.2.2 && git push origin v4.2.2` → release goes green and publishes to PyPI

## Cleanup (optional, post-merge)

Delete the dead tags from the failed runs (nothing was published):

```bash
git push origin :refs/tags/v4.2.0 :refs/tags/v4.2.1
```

Made with [Cursor](https://cursor.com)