### PR TITLE
Check out repo in create-release job so gh release create works

### DIFF
--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -69,6 +69,14 @@ jobs:
       attestations: write
 
     steps:
+      - name: Check out repository
+        # gh release create --generate-notes shells out to git; without a
+        # checkout it fails with "fatal: not a git repository". fetch-depth 0
+        # gives it the full tag/commit history for note generation.
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
       - name: Download all the dists
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:


### PR DESCRIPTION
## Why

The `v4.2.2` release run published to PyPI successfully, but the **Create GitHub Release** step failed:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The `create-release` job has no `actions/checkout`, so `gh release create --generate-notes` (which shells out to `git`) had no repo on disk. The build and publish jobs were unaffected because they only download the prebuilt artifact.

(The `v4.2.2` GitHub Release was created manually from the run's CI-built artifacts — byte-identical to PyPI — so nothing is missing for that version. This fix prevents recurrence for future releases.)

## Change

- Add `actions/checkout` (pinned, `fetch-depth: 0`) as the first step of the `create-release` job so `gh release create --generate-notes` has the tag/commit history.

## Test plan

- [x] No version bump (workflow-only change)
- [ ] Next tagged release: the **Create GitHub Release** job completes and the release carries the CI artifacts + auto-generated notes

Made with [Cursor](https://cursor.com)