### PR TITLE
feat(APP-2497): add mainline self-hosted endpoint config

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ The canonical pysynthbio docs live at [docs.synthesize.bio/pysynthbio](https://d
 - [Get started](https://docs.synthesize.bio/pysynthbio/getting-started)
 - [Installation](https://docs.synthesize.bio/pysynthbio/installation)
 - [Models](https://docs.synthesize.bio/pysynthbio/models/baseline)
+- [Self-hosted models](https://docs.synthesize.bio/pysynthbio/self-hosted)
+
+For self-hosted model containers, install the Arrow extra with
+`pip install "pysynthbio[self_hosted]"`, then configure model endpoints with
+`pysynthbio.configure(...)`, environment variables such as
+`SYNTHESIZE_ENDPOINT_GEM_1_BULK`, or `$SYNTHESIZE_CONFIG`.
 
 The legacy GitHub Pages site at `synthesizebio.github.io/pysynthbio` redirects to the new URLs and is no longer updated. The MDX source for the customer-facing docs lives in [`docs-external/`](./docs-external) and is aggregated into [`docs-external`](https://github.com/synthesizebio/docs-external) by the Mintlify multirepo workflow.
 

--- a/docs-external/self-hosted.mdx
+++ b/docs-external/self-hosted.mdx
@@ -49,17 +49,36 @@ os.environ["SYNTHESIZE_SELF_HOSTED"] = "1"
 
 Self-hosted deployments typically run one container per model. Set a per-model
 base URL once and you never have to pass `api_base_url` on individual calls.
-The variable name is `SYNTHESIZE_API_BASE_URL__<MODEL>`, where `<MODEL>` is the
-upper-cased model id with non-alphanumeric characters replaced by underscores
-(for example, `gem-1-bulk` becomes `SYNTHESIZE_API_BASE_URL__GEM_1_BULK`).
+You can configure endpoints in Python, with environment variables, or with a
+TOML config file.
+
+### Configure in Python
+
+Call `pysynthbio.configure(...)` once near process startup:
+
+```python
+import pysynthbio
+
+pysynthbio.configure(
+    self_hosted=True,
+    endpoint_gem_1_bulk="https://gem-1-bulk.internal.example",
+    endpoint_gem_1_sc="https://gem-1-sc.internal.example",
+    endpoint_gem_2="https://gem-2.internal.example",
+)
+```
+
+### Configure with environment variables
+
+Set the per-model endpoint variables for the containers you run:
 
 ```python
 import os
 
 import pysynthbio
 
-os.environ["SYNTHESIZE_API_BASE_URL__GEM_1_BULK"] = "https://gem-1-bulk.internal.example"
-os.environ["SYNTHESIZE_API_BASE_URL__GEM_1_SC"] = "https://gem-1-sc.internal.example"
+os.environ["SYNTHESIZE_ENDPOINT_GEM_1_BULK"] = "https://gem-1-bulk.internal.example"
+os.environ["SYNTHESIZE_ENDPOINT_GEM_1_SC"] = "https://gem-1-sc.internal.example"
+os.environ["SYNTHESIZE_ENDPOINT_GEM_2"] = "https://gem-2.internal.example"
 
 query = pysynthbio.get_example_query("gem-1-bulk", self_hosted=True)["example_query"]
 result = pysynthbio.predict_query(query, model_id="gem-1-bulk", self_hosted=True)
@@ -72,14 +91,33 @@ Variant slugs backed by the same container (for example,
 `gem-1-bulk_reference-conditioning` and `gem-1-bulk_predict-metadata`) resolve
 to the same per-model variable as their base model.
 
+### Configure with a file
+
+By default `pysynthbio` reads `~/.config/synthbio/config.toml`. Set
+`SYNTHESIZE_CONFIG` to point at a different file.
+
+```toml
+self_hosted = true
+api_base_url = "https://app.synthesize.bio"
+
+[model_endpoints]
+gem_1_bulk = "https://gem-1-bulk.internal.example"
+gem_1_sc = "https://gem-1-sc.internal.example"
+gem_2 = "https://gem-2.internal.example"
+```
+
 ### Resolution precedence
 
 The base URL is resolved in this order:
 
 1. An explicit `api_base_url` argument passed to the call.
-2. The per-model variable `SYNTHESIZE_API_BASE_URL__<MODEL>`.
-3. The global `SYNTHESIZE_API_BASE_URL`.
-4. The production default (`https://app.synthesize.bio`).
+2. Values passed to `pysynthbio.configure(...)`.
+3. Per-model environment variables (`SYNTHESIZE_ENDPOINT_GEM_1_BULK`,
+   `SYNTHESIZE_ENDPOINT_GEM_1_SC`, `SYNTHESIZE_ENDPOINT_GEM_2`).
+4. The global `SYNTHESIZE_API_BASE_URL`.
+5. The config file (`$SYNTHESIZE_CONFIG` or
+   `~/.config/synthbio/config.toml`).
+6. The production default (`https://app.synthesize.bio`).
 
 You can always override the environment by passing `api_base_url` directly:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pysynthbio"
-version = "4.2.2"
+version = "4.3.0"
 requires-python = ">=3.10"
 description = "A package to retrieve data and models from Synthesize Bio's API"
 authors = [
@@ -14,6 +14,7 @@ dependencies = [
     "pandas>=2.2.3",
     "requests",
     "keyring>=23.0.0",
+    "tomli>=2.0.0; python_version < '3.11'",
 ]
 
 [build-system]

--- a/src/pysynthbio/__init__.py
+++ b/src/pysynthbio/__init__.py
@@ -23,6 +23,9 @@ from .http_client import (
 from .http_client import (
     ValidationError as ValidationError,
 )
+from .http_client import (
+    configure as configure,
+)
 from .key_handlers import (
     clear_synthesize_token as clear_synthesize_token,
 )

--- a/src/pysynthbio/call_model_api.py
+++ b/src/pysynthbio/call_model_api.py
@@ -130,8 +130,9 @@ def predict_query(
         synchronously as an Apache Arrow stream (no polling, no download URL).
         Can also be enabled via the ``SYNTHESIZE_SELF_HOSTED`` environment
         variable. The container's base URL is taken from ``api_base_url``, then
-        the per-model env var ``SYNTHESIZE_API_BASE_URL__<MODEL>`` (e.g.
-        ``SYNTHESIZE_API_BASE_URL__GEM_1_BULK``), then ``SYNTHESIZE_API_BASE_URL``.
+        ``pysynthbio.configure(...)``, then per-model env vars such as
+        ``SYNTHESIZE_ENDPOINT_GEM_1_BULK``, then ``SYNTHESIZE_API_BASE_URL``,
+        then the config file.
         Authentication is optional and only sent when ``SYNTHESIZE_API_KEY`` is
         set. Default False.
     **kwargs : dict, optional

--- a/src/pysynthbio/get_example_query.py
+++ b/src/pysynthbio/get_example_query.py
@@ -23,9 +23,9 @@ def get_example_query(
     model_id : str
         The ID of the model to get an example query for.
     api_base_url : str, optional
-        Base URL for the API server. Defaults to the per-model env var
-        ``SYNTHESIZE_API_BASE_URL__<MODEL>``, then ``SYNTHESIZE_API_BASE_URL``,
-        then the production host.
+        Base URL for the API server. Defaults to configured per-model endpoints,
+        then env vars such as ``SYNTHESIZE_ENDPOINT_GEM_1_BULK``, then
+        ``SYNTHESIZE_API_BASE_URL``, then the config file, then production.
     self_hosted : bool, optional
         Talk to a self-hosted container (auth optional). Defaults to the
         ``SYNTHESIZE_SELF_HOSTED`` environment variable.

--- a/src/pysynthbio/http_client.py
+++ b/src/pysynthbio/http_client.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+from pathlib import Path
 from typing import Any, Optional
 
 import requests
@@ -22,6 +23,20 @@ ARROW_STREAM_CONTENT_TYPE = "application/vnd.apache.arrow.stream"
 # self-hosted container without code changes.
 SELF_HOSTED_ENV = "SYNTHESIZE_SELF_HOSTED"
 API_BASE_URL_ENV = "SYNTHESIZE_API_BASE_URL"
+CONFIG_FILE_ENV = "SYNTHESIZE_CONFIG"
+DEFAULT_CONFIG_PATH = "~/.config/synthbio/config.toml"
+
+_MODEL_ENDPOINT_ENVS = {
+    "gem-1-bulk": "SYNTHESIZE_ENDPOINT_GEM_1_BULK",
+    "gem-1-sc": "SYNTHESIZE_ENDPOINT_GEM_1_SC",
+    "gem-2": "SYNTHESIZE_ENDPOINT_GEM_2",
+}
+
+_CONFIG: dict[str, Any] = {
+    "api_base_url": None,
+    "self_hosted": None,
+    "model_endpoints": {},
+}
 
 
 def env_flag(name: str) -> bool:
@@ -45,11 +60,132 @@ def _base_model_id(model_id: str) -> str:
 def per_model_env_var(model_id: str) -> str:
     """Env var holding the self-hosted base URL for a specific model.
 
-    The base model and all its variants map to one variable, e.g. ``gem-1-bulk``,
-    ``gem-1-bulk_predict-metadata`` -> ``SYNTHESIZE_API_BASE_URL__GEM_1_BULK``.
+    The base model and all its variants map to one variable, e.g.
+    ``gem-1-bulk`` and ``gem-1-bulk_predict-metadata`` both resolve to
+    ``SYNTHESIZE_ENDPOINT_GEM_1_BULK``.
     """
+    base_model_id = _base_model_id(model_id)
+    if base_model_id in _MODEL_ENDPOINT_ENVS:
+        return _MODEL_ENDPOINT_ENVS[base_model_id]
+    key = re.sub(r"[^A-Z0-9]+", "_", base_model_id.upper())
+    return f"SYNTHESIZE_ENDPOINT_{key}"
+
+
+def legacy_per_model_env_var(model_id: str) -> str:
+    """Previous per-model env var spelling kept for backward compatibility."""
     key = re.sub(r"[^A-Z0-9]+", "_", _base_model_id(model_id).upper())
     return f"{API_BASE_URL_ENV}__{key}"
+
+
+def _model_config_key(model_id: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", _base_model_id(model_id).lower()).strip("_")
+
+
+def _normalize_base_url(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    value = str(value).strip()
+    if not value:
+        return None
+    return value.rstrip("/")
+
+
+def _load_toml(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        import tomllib  # type: ignore[attr-defined]
+    except ModuleNotFoundError:  # pragma: no cover - Python 3.10 only
+        import tomli as tomllib
+
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def _config_file_path() -> Path:
+    return Path(os.environ.get(CONFIG_FILE_ENV, DEFAULT_CONFIG_PATH)).expanduser()
+
+
+def _file_config() -> dict:
+    return _load_toml(_config_file_path())
+
+
+def _configured_endpoint(model_id: str) -> Optional[str]:
+    return _normalize_base_url(_CONFIG["model_endpoints"].get(_base_model_id(model_id)))
+
+
+def _env_endpoint(model_id: str) -> Optional[str]:
+    return _normalize_base_url(
+        os.environ.get(per_model_env_var(model_id))
+        or os.environ.get(legacy_per_model_env_var(model_id))
+    )
+
+
+def _file_endpoint(config: dict, model_id: str) -> Optional[str]:
+    base_model_id = _base_model_id(model_id)
+    key = _model_config_key(model_id)
+    candidates = (
+        f"endpoint_{key}",
+        f"endpoint_{key.upper()}",
+        base_model_id,
+        key,
+        key.upper(),
+    )
+
+    for candidate in candidates:
+        value = _normalize_base_url(config.get(candidate))
+        if value:
+            return value
+
+    for section_name in ("model_endpoints", "endpoints"):
+        section = config.get(section_name)
+        if not isinstance(section, dict):
+            continue
+        for candidate in candidates[2:]:
+            value = _normalize_base_url(section.get(candidate))
+            if value:
+                return value
+    return None
+
+
+def configure(
+    *,
+    api_base_url: Optional[str] = None,
+    endpoint_gem_1_bulk: Optional[str] = None,
+    endpoint_gem_1_sc: Optional[str] = None,
+    endpoint_gem_2: Optional[str] = None,
+    model_endpoints: Optional[dict[str, str]] = None,
+    self_hosted: Optional[bool] = None,
+    reset: bool = False,
+) -> None:
+    """Configure default endpoints for the current Python process.
+
+    Values passed here have higher precedence than environment variables and
+    config files. Passing ``reset=True`` clears previous process-level settings
+    before applying the provided values.
+    """
+    if reset:
+        _CONFIG["api_base_url"] = None
+        _CONFIG["self_hosted"] = None
+        _CONFIG["model_endpoints"] = {}
+
+    if api_base_url is not None:
+        _CONFIG["api_base_url"] = _normalize_base_url(api_base_url)
+    if self_hosted is not None:
+        _CONFIG["self_hosted"] = bool(self_hosted)
+
+    endpoints = {
+        "gem-1-bulk": endpoint_gem_1_bulk,
+        "gem-1-sc": endpoint_gem_1_sc,
+        "gem-2": endpoint_gem_2,
+    }
+    if model_endpoints:
+        endpoints.update({_base_model_id(k): v for k, v in model_endpoints.items()})
+
+    for model_id, endpoint in endpoints.items():
+        normalized = _normalize_base_url(endpoint)
+        if normalized:
+            _CONFIG["model_endpoints"][_base_model_id(model_id)] = normalized
 
 
 def resolve_base_url(
@@ -57,24 +193,55 @@ def resolve_base_url(
 ) -> str:
     """Resolve the API base URL for a request.
 
-    Precedence: explicit ``api_base_url`` arg > per-model env var
-    (``SYNTHESIZE_API_BASE_URL__<MODEL>``) > global ``SYNTHESIZE_API_BASE_URL`` >
-    production default. The per-model variable lets a scientist point each model
-    at its own self-hosted container once and never pass a URL on every call.
+    Precedence: explicit per-call ``api_base_url`` arg > ``configure(...)`` >
+    env vars > config file > production default.
     """
-    if api_base_url and api_base_url != API_BASE_URL:
-        return api_base_url
+    explicit_base_url = _normalize_base_url(api_base_url)
+    if explicit_base_url and explicit_base_url != API_BASE_URL:
+        return explicit_base_url
+
     if model_id:
-        per_model = os.environ.get(per_model_env_var(model_id))
-        if per_model:
-            return per_model
-    return os.environ.get(API_BASE_URL_ENV, API_BASE_URL)
+        configured = _configured_endpoint(model_id)
+        if configured:
+            return configured
+
+    configured_base_url = _normalize_base_url(_CONFIG.get("api_base_url"))
+    if configured_base_url:
+        return configured_base_url
+
+    if model_id:
+        env_endpoint = _env_endpoint(model_id)
+        if env_endpoint:
+            return env_endpoint
+
+    env_base_url = _normalize_base_url(os.environ.get(API_BASE_URL_ENV))
+    if env_base_url:
+        return env_base_url
+
+    config = _file_config()
+    if model_id:
+        config_endpoint = _file_endpoint(config, model_id)
+        if config_endpoint:
+            return config_endpoint
+
+    config_base_url = _normalize_base_url(config.get("api_base_url"))
+    if config_base_url:
+        return config_base_url
+
+    return API_BASE_URL
 
 
 def self_hosted_enabled(explicit: Optional[bool] = None) -> bool:
-    """Resolve self-hosted mode: explicit arg wins, else the env flag."""
+    """Resolve self-hosted mode: explicit arg > configure > env > config file."""
     if explicit is not None:
         return explicit
+    if _CONFIG["self_hosted"] is not None:
+        return bool(_CONFIG["self_hosted"])
+    if SELF_HOSTED_ENV in os.environ:
+        return env_flag(SELF_HOSTED_ENV)
+    config = _file_config()
+    if "self_hosted" in config:
+        return bool(config["self_hosted"])
     return env_flag(SELF_HOSTED_ENV)
 
 

--- a/tests/test_arrow_transformers.py
+++ b/tests/test_arrow_transformers.py
@@ -6,11 +6,14 @@ metadata carries ``request_type``, ``model_version`` and ``gene_order``.
 """
 
 import json
+from io import BytesIO
+from unittest import mock
 
 import pyarrow as pa
 import pyarrow.ipc as ipc
 
 from pysynthbio.arrow_transformers import transform_arrow_stream
+from pysynthbio.call_model_api import predict_query
 
 GENE_ORDER = ["ENSG1", "ENSG2", "ENSG3"]
 
@@ -90,3 +93,41 @@ def test_predict_metadata_stream_to_frames():
     assert set(result) == {"metadata", "latents", "classifier_probs", "expression"}
     assert result["expression"].iloc[0].tolist() == [1, 2, 3]
     assert result["metadata"].iloc[0]["sex"] == "male"
+
+
+def test_predict_query_self_hosted_posts_and_decodes_arrow(monkeypatch):
+    monkeypatch.delenv("SYNTHESIZE_API_KEY", raising=False)
+    captured = {}
+
+    class FakeResponse:
+        def __init__(self, payload: bytes):
+            self.raw = BytesIO(payload)
+            self.content = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    def fake_open_arrow_stream(endpoint, api_base_url, json, timeout):
+        captured["endpoint"] = endpoint
+        captured["api_base_url"] = api_base_url
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return FakeResponse(_baseline_stream())
+
+    with mock.patch(
+        "pysynthbio.call_model_api.open_arrow_stream", fake_open_arrow_stream
+    ):
+        result = predict_query(
+            {"inputs": [{"sex": "male"}]},
+            model_id="gem-1-bulk",
+            api_base_url="http://box:8080",
+            self_hosted=True,
+        )
+
+    assert captured["endpoint"] == "/api/models/gem-1-bulk/predict"
+    assert captured["api_base_url"] == "http://box:8080"
+    assert captured["json"]["source"] == "pysynthbio"
+    assert result["expression"].iloc[0].tolist() == [1, 2, 3]

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -10,12 +10,14 @@ import requests
 
 from pysynthbio.call_model_api import _clean_error_message
 from pysynthbio.http_client import (
+    ARROW_STREAM_CONTENT_TYPE,
     AuthenticationError,
     NotFoundError,
     SynthesizeAPIError,
     ValidationError,
     api_request,
     get_json,
+    open_arrow_stream,
 )
 
 
@@ -232,6 +234,55 @@ class TestGetJson(unittest.TestCase):
             get_json("https://example.com/data.json")
 
         self.assertEqual(context.exception.status_code, 403)
+
+
+class TestOpenArrowStream(unittest.TestCase):
+    """Test cases for self-hosted Arrow stream requests."""
+
+    def setUp(self):
+        self.original_api_key = os.environ.get("SYNTHESIZE_API_KEY")
+
+    def tearDown(self):
+        if self.original_api_key is not None:
+            os.environ["SYNTHESIZE_API_KEY"] = self.original_api_key
+        elif "SYNTHESIZE_API_KEY" in os.environ:
+            del os.environ["SYNTHESIZE_API_KEY"]
+
+    @patch("pysynthbio.http_client.requests.post")
+    def test_no_authorization_header_without_token(self, mock_post):
+        os.environ.pop("SYNTHESIZE_API_KEY", None)
+        mock_response = MagicMock()
+        mock_response.raw = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        open_arrow_stream(
+            "/api/models/gem-1-bulk/predict",
+            api_base_url="http://box:8080",
+            json={"inputs": []},
+        )
+
+        headers = mock_post.call_args.kwargs["headers"]
+        self.assertEqual(headers["Accept"], ARROW_STREAM_CONTENT_TYPE)
+        self.assertNotIn("Authorization", headers)
+        self.assertTrue(mock_post.call_args.kwargs["stream"])
+
+    @patch("pysynthbio.http_client.requests.post")
+    def test_authorization_header_with_token(self, mock_post):
+        os.environ["SYNTHESIZE_API_KEY"] = "sbio_test"
+        mock_response = MagicMock()
+        mock_response.raw = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        open_arrow_stream(
+            "/api/models/gem-1-bulk/predict",
+            api_base_url="http://box:8080",
+            json={"inputs": []},
+        )
+
+        headers = mock_post.call_args.kwargs["headers"]
+        self.assertEqual(headers["Authorization"], "Bearer sbio_test")
 
 
 class TestExceptionHierarchy(unittest.TestCase):

--- a/tests/test_self_hosted_config.py
+++ b/tests/test_self_hosted_config.py
@@ -2,14 +2,33 @@
 
 from unittest import mock
 
+import pytest
+
 import pysynthbio
 from pysynthbio.http_client import (
     API_BASE_URL,
+    configure,
     env_flag,
+    legacy_per_model_env_var,
     per_model_env_var,
     resolve_base_url,
     self_hosted_enabled,
 )
+
+
+@pytest.fixture(autouse=True)
+def reset_config(monkeypatch):
+    configure(reset=True)
+    monkeypatch.delenv("SYNTHESIZE_CONFIG", raising=False)
+    monkeypatch.delenv("SYNTHESIZE_SELF_HOSTED", raising=False)
+    monkeypatch.delenv("SYNTHESIZE_API_BASE_URL", raising=False)
+    monkeypatch.delenv("SYNTHESIZE_ENDPOINT_GEM_1_BULK", raising=False)
+    monkeypatch.delenv("SYNTHESIZE_ENDPOINT_GEM_1_SC", raising=False)
+    monkeypatch.delenv("SYNTHESIZE_ENDPOINT_GEM_2", raising=False)
+    monkeypatch.delenv("SYNTHESIZE_API_BASE_URL__GEM_1_BULK", raising=False)
+    monkeypatch.delenv("SYNTHESIZE_API_BASE_URL__GEM_1_SC", raising=False)
+    yield
+    configure(reset=True)
 
 
 def test_env_flag_truthy_values(monkeypatch):
@@ -31,23 +50,23 @@ def test_resolve_base_url_precedence(monkeypatch):
 
 
 def test_per_model_env_var_naming():
-    assert per_model_env_var("gem-1-bulk") == "SYNTHESIZE_API_BASE_URL__GEM_1_BULK"
-    assert per_model_env_var("gem-1-sc") == "SYNTHESIZE_API_BASE_URL__GEM_1_SC"
+    assert per_model_env_var("gem-1-bulk") == "SYNTHESIZE_ENDPOINT_GEM_1_BULK"
+    assert per_model_env_var("gem-1-sc") == "SYNTHESIZE_ENDPOINT_GEM_1_SC"
+    assert per_model_env_var("gem-2") == "SYNTHESIZE_ENDPOINT_GEM_2"
     # Variant slugs normalize to their base model's variable.
     assert (
         per_model_env_var("gem-1-bulk_predict-metadata")
-        == "SYNTHESIZE_API_BASE_URL__GEM_1_BULK"
+        == "SYNTHESIZE_ENDPOINT_GEM_1_BULK"
     )
     assert (
         per_model_env_var("gem-1-sc_reference-conditioning")
-        == "SYNTHESIZE_API_BASE_URL__GEM_1_SC"
+        == "SYNTHESIZE_ENDPOINT_GEM_1_SC"
     )
 
 
 def test_resolve_base_url_per_model(monkeypatch):
-    monkeypatch.delenv("SYNTHESIZE_API_BASE_URL", raising=False)
-    monkeypatch.setenv("SYNTHESIZE_API_BASE_URL__GEM_1_BULK", "http://bulk:8080")
-    monkeypatch.setenv("SYNTHESIZE_API_BASE_URL__GEM_1_SC", "http://sc:8080")
+    monkeypatch.setenv("SYNTHESIZE_ENDPOINT_GEM_1_BULK", "http://bulk:8080/")
+    monkeypatch.setenv("SYNTHESIZE_ENDPOINT_GEM_1_SC", "http://sc:8080")
 
     # Each model resolves to its own host, no per-call URL needed.
     assert resolve_base_url(model_id="gem-1-bulk") == "http://bulk:8080"
@@ -72,11 +91,67 @@ def test_resolve_base_url_per_model(monkeypatch):
 
 def test_resolve_base_url_per_model_beats_global(monkeypatch):
     monkeypatch.setenv("SYNTHESIZE_API_BASE_URL", "http://global:8080")
-    monkeypatch.setenv("SYNTHESIZE_API_BASE_URL__GEM_1_SC", "http://sc:8080")
+    monkeypatch.setenv("SYNTHESIZE_ENDPOINT_GEM_1_SC", "http://sc:8080")
     # Per-model wins over global when present...
     assert resolve_base_url(model_id="gem-1-sc") == "http://sc:8080"
     # ...but a model without its own var uses the global.
     assert resolve_base_url(model_id="gem-1-bulk") == "http://global:8080"
+
+
+def test_legacy_per_model_env_var_is_still_supported(monkeypatch):
+    assert (
+        legacy_per_model_env_var("gem-1-bulk") == "SYNTHESIZE_API_BASE_URL__GEM_1_BULK"
+    )
+    monkeypatch.setenv("SYNTHESIZE_API_BASE_URL__GEM_1_BULK", "http://legacy:8080")
+    assert resolve_base_url(model_id="gem-1-bulk") == "http://legacy:8080"
+
+
+def test_configure_precedence(monkeypatch):
+    monkeypatch.setenv("SYNTHESIZE_ENDPOINT_GEM_1_BULK", "http://env-bulk:8080")
+    monkeypatch.setenv("SYNTHESIZE_API_BASE_URL", "http://env-global:8080")
+
+    configure(
+        api_base_url="http://configured-global:8080",
+        endpoint_gem_1_bulk="http://configured-bulk:8080",
+        model_endpoints={"gem-1-sc": "http://configured-sc:8080"},
+        self_hosted=True,
+    )
+
+    assert resolve_base_url(model_id="gem-1-bulk") == "http://configured-bulk:8080"
+    assert resolve_base_url(model_id="gem-1-sc") == "http://configured-sc:8080"
+    assert resolve_base_url(model_id="gem-2") == "http://configured-global:8080"
+    assert (
+        resolve_base_url("http://per-call:8080", model_id="gem-1-bulk")
+        == "http://per-call:8080"
+    )
+    assert self_hosted_enabled(None) is True
+
+
+def test_config_file_resolution(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("""
+api_base_url = "http://file-global:8080"
+self_hosted = true
+
+[model_endpoints]
+gem_1_bulk = "http://file-bulk:8080"
+"gem-1-sc" = "http://file-sc:8080"
+""".strip())
+    monkeypatch.setenv("SYNTHESIZE_CONFIG", str(config_path))
+
+    assert resolve_base_url(model_id="gem-1-bulk") == "http://file-bulk:8080"
+    assert resolve_base_url(model_id="gem-1-sc") == "http://file-sc:8080"
+    assert resolve_base_url(model_id="gem-2") == "http://file-global:8080"
+    assert self_hosted_enabled(None) is True
+
+
+def test_env_beats_config_file(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text('api_base_url = "http://file-global:8080"\n')
+    monkeypatch.setenv("SYNTHESIZE_CONFIG", str(config_path))
+    monkeypatch.setenv("SYNTHESIZE_API_BASE_URL", "http://env-global:8080")
+
+    assert resolve_base_url(model_id="gem-2") == "http://env-global:8080"
 
 
 def test_self_hosted_enabled_precedence(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -891,13 +891,14 @@ wheels = [
 
 [[package]]
 name = "pysynthbio"
-version = "4.2.2"
+version = "4.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "keyring" },
     { name = "numpy" },
     { name = "pandas" },
     { name = "requests" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
 [package.optional-dependencies]
@@ -936,6 +937,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "requests" },
     { name = "ruff", marker = "extra == 'dev'" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
 ]
 provides-extras = ["secure", "self-hosted", "all", "dev"]
 


### PR DESCRIPTION
## Summary
- Adds `pysynthbio.configure(...)` and APP-2497 endpoint/config precedence for self-hosted deployments.
- Supports the requested `SYNTHESIZE_ENDPOINT_GEM_1_BULK`, `SYNTHESIZE_ENDPOINT_GEM_1_SC`, `SYNTHESIZE_ENDPOINT_GEM_2`, `$SYNTHESIZE_CONFIG`, and `~/.config/synthbio/config.toml` paths while preserving legacy per-model env aliases.
- Updates self-hosted docs, README, package metadata, and tests for optional bearer auth plus Arrow direct decoding.

## Test plan
- `uv run --extra dev --extra self_hosted pytest`
- `uv run --extra dev --extra self_hosted ruff check .`
- `uv run --extra dev --extra self_hosted black --check .`


Made with [Cursor](https://cursor.com)